### PR TITLE
Add open options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Crates.io](https://img.shields.io/crates/v/coldcard.svg)](https://crates.io/crates/coldcard)
 [![License](https://img.shields.io/crates/l/coldcard.svg)](https://github.com/alred-hodler/rust-coldcard/blob/master/coldcard/LICENSE)
 
-This is a workspace that contains projects used for interfacing with the [Coldcard](https://coldcard.com/) hardware wallet.
+This is a workspace that contains crates used for interfacing with the [Coldcard](https://coldcard.com/) hardware wallet.
 
 ![Project Logo](logo.png)
 
-The projects are as follows:
+The crates are as follows:
 
 `coldcard` - the library for integration with Rust projects
 

--- a/coldcard-cli/Cargo.toml
+++ b/coldcard-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldcard-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Alfred Hodler <alfred_hodler AT protonmail DOT com>"]
 license = "MIT"
@@ -14,7 +14,7 @@ name = "coldcard"
 path = "src/main.rs"
 
 [dependencies]
-coldcard = { version = "0.2.1", path = "../coldcard" }
+coldcard = { version = "0.3.0", path = "../coldcard" }
 base64 = "0.13.0"
 clap = { version = "3.1.6", features = ["derive"] }
 hex = "0.4.3"

--- a/coldcard-cli/src/main.rs
+++ b/coldcard-cli/src/main.rs
@@ -231,7 +231,7 @@ fn main() -> Result<(), Error> {
     }
     .ok_or(coldcard::Error::NoColdcard)?;
 
-    let (mut cc, xpub_info) = sn.open()?;
+    let (mut cc, xpub_info) = sn.open(None)?;
 
     // check for MITM if requested
     let expected_xpub = cli.xpub;

--- a/coldcard/Cargo.toml
+++ b/coldcard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldcard"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Alfred Hodler <alfred_hodler AT protonmail DOT com>"]
 license = "MIT"


### PR DESCRIPTION
This adds an `Options` struct that can specify various options when opening a Coldcard.