### PR TITLE
Add remote CLI passthrough

### DIFF
--- a/coldcard-cli/Cargo.toml
+++ b/coldcard-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldcard-cli"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["Alfred Hodler <alfred_hodler AT protonmail DOT com>"]
 license = "MIT"
@@ -14,10 +14,15 @@ name = "coldcard"
 path = "src/main.rs"
 
 [dependencies]
+bincode = "1.3.3"
 coldcard = { version = "0.3.0", path = "../coldcard" }
+dirs = "4.0.0"
 base64 = "0.13.0"
 clap = { version = "3.1.6", features = ["derive"] }
 hex = "0.4.3"
 hmac-sha256 = "1.1.2"
 json = "0.12.4"
+libtor = "47.7.0+0.4.7.x"
 rpassword = "6.0.1"
+serde = "1.0.137"
+socks = "0.3.4"

--- a/coldcard-cli/README.md
+++ b/coldcard-cli/README.md
@@ -13,17 +13,33 @@ Usage:
 ```bash
 $ coldcard --help
 
-coldcard-cli 0.2.1
+coldcard-cli 0.3.0
 Coldcard Wallet CLI Tool
 
 USAGE:
     coldcard [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
-    -h, --help               Print help information
-        --serial <SERIAL>    The Coldcard serial number to operate on (default: first one found)
-    -V, --version            Print version information
-        --xpub <XPUB>        Perform a MITM check against an xpub
+    -h, --help
+            Print help information
+
+        --hidden-service <HIDDEN_SERVICE>
+            The .onion address representing a remote Coldcard to connect to
+
+        --password <PASSWORD>
+            The authentication password for a remote Coldcard service
+
+        --serial <SERIAL>
+            The Coldcard serial number to operate on (default: first one found)
+
+        --socks-port <SOCKS_PORT>
+            The socks5 port of the local Tor proxy when executing a remote command [default: 9150]
+
+    -V, --version
+            Print version information
+
+        --xpub <XPUB>
+            Perform a MITM check against an xpub
 
 SUBCOMMANDS:
     address        Show the address for a derivation path
@@ -43,6 +59,7 @@ SUBCOMMANDS:
     passphrase     Set a BIP39 passphrase
     pubkey         Show the pubkey for a derivation path
     reboot         Reboot the Coldcard
+    server         Bind the Coldcard to a V3 Tor Hidden Service for remote interaction
     sign           Sign a spending PSBT transaction
     test           Test USB connection
     upgrade        Upgrade the firmware
@@ -50,6 +67,25 @@ SUBCOMMANDS:
     version        Show the version information of this Coldcard
     xfp            Show the master fingerprint for this wallet
     xpub           Show the xpub (default: master)
+```
+
+## Remote mode
+
+It is possible to start the CLI in the server mode, binding it to a locally connected Coldcard. This
+creates a V3 Tor hidden service and exposes it on port 8000. It then becomes possible to issue a
+limited subset of CLI commands to this service through Tor.
+
+The server would execute:
+
+```bash
+$ coldcard server password123
+Serving at ccbr3lbye4rrtynoih4mhbligh6ays3s2w6ns7pzp7ouvj7kg5viizad.onion:8000
+```
+
+The client might then initiate remote PSBT signing:
+
+```bash
+$ coldcard --hidden-service ccbr3lbye4rrtynoih4mhbligh6ays3s2w6ns7pzp7ouvj7kg5viizad.onion:8000 --password password123 sign ~/testnet-182b6376.psbt finalize
 ```
 
 ## Library

--- a/coldcard-cli/README.md
+++ b/coldcard-cli/README.md
@@ -26,9 +26,6 @@ OPTIONS:
         --hidden-service <HIDDEN_SERVICE>
             The .onion address representing a remote Coldcard to connect to
 
-        --password <PASSWORD>
-            The authentication password for a remote Coldcard service
-
         --serial <SERIAL>
             The Coldcard serial number to operate on (default: first one found)
 
@@ -85,7 +82,7 @@ Serving at ccbr3lbye4rrtynoih4mhbligh6ays3s2w6ns7pzp7ouvj7kg5viizad.onion:8000
 The client might then initiate remote PSBT signing:
 
 ```bash
-$ coldcard --hidden-service ccbr3lbye4rrtynoih4mhbligh6ays3s2w6ns7pzp7ouvj7kg5viizad.onion:8000 --password password123 sign ~/testnet-182b6376.psbt finalize
+$ coldcard --hidden-service ccbr3lbye4rrtynoih4mhbligh6ays3s2w6ns7pzp7ouvj7kg5viizad.onion:8000 sign ~/testnet-182b6376.psbt finalize
 ```
 
 ## Library

--- a/coldcard-cli/src/main.rs
+++ b/coldcard-cli/src/main.rs
@@ -26,10 +26,6 @@ struct Cli {
     #[clap(long)]
     hidden_service: Option<String>,
 
-    /// The authentication password for a remote Coldcard service
-    #[clap(long)]
-    password: Option<String>,
-
     /// The socks5 port of the local Tor proxy when executing a remote command
     #[clap(long, default_value = "9150")]
     socks_port: u16,

--- a/coldcard-cli/src/remote.rs
+++ b/coldcard-cli/src/remote.rs
@@ -61,7 +61,7 @@ pub(crate) fn handle(cli: Cli) -> Result<(), Error> {
         }
     }
 
-    let password = cli.password.unwrap_or_default();
+    let password = rpassword::prompt_password("Enter the password for the remote service: ")?;
 
     match cli.command {
         Command::Logout => {

--- a/coldcard-cli/src/remote.rs
+++ b/coldcard-cli/src/remote.rs
@@ -33,6 +33,10 @@ pub enum RemoteResponse {
 
 /// Handles a CLI command meant for a remote service.
 pub(crate) fn handle(cli: Cli) -> Result<(), Error> {
+    if !is_remote(&cli.command) {
+        return Err(RemoteError::NotRemoteCommand.into());
+    }
+
     let target = cli.hidden_service.unwrap();
     let proxy = format!("localhost:{}", cli.socks_port);
     let mut stream = socks::Socks5Stream::connect(&proxy, target.as_str())?;
@@ -223,6 +227,14 @@ pub(crate) fn listen(mut cc: Coldcard, password: &str) -> Result<(), Error> {
 
         // throttle incoming requests to prevent grinding attacks
         std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+fn is_remote(command: &Command) -> bool {
+    match command {
+        Command::Logout => true,
+        Command::Sign { .. } => true,
+        _ => false,
     }
 }
 

--- a/coldcard-cli/src/remote.rs
+++ b/coldcard-cli/src/remote.rs
@@ -1,0 +1,241 @@
+use std::fs::File;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+use coldcard::Coldcard;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Command;
+use crate::Error;
+use crate::{Cli, SignMode};
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct RemoteRequest {
+    password: String,
+    command: RemoteCommand,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) enum RemoteCommand {
+    Logout,
+    SignPsbt { mode: SignMode, psbt: Vec<u8> },
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum RemoteResponse {
+    Ok,
+    Psbt(Vec<u8>),
+    BadAuth,
+    Refused,
+    ServerError,
+}
+
+/// Handles a CLI command meant for a remote service.
+pub(crate) fn handle(cli: Cli) -> Result<(), Error> {
+    let target = cli.hidden_service.unwrap();
+    let proxy = format!("localhost:{}", cli.socks_port);
+    let mut stream = socks::Socks5Stream::connect(&proxy, target.as_str())?;
+
+    fn send_receive<T>(stream: &mut T, request: RemoteRequest) -> Result<RemoteResponse, Error>
+    where
+        T: Read + Write,
+    {
+        let data = bincode::serialize(&request)?;
+        stream.write_all(&(data.len() as u32).to_le_bytes())?;
+        stream.write_all(&data)?;
+
+        let mut response_len = [0_u8; 4];
+        stream.read_exact(&mut response_len)?;
+        let response_len = u32::from_le_bytes(response_len) as usize;
+
+        let mut response = vec![0_u8; response_len];
+        stream.read_exact(&mut response)?;
+
+        let response: RemoteResponse = bincode::deserialize(&response)?;
+
+        match response {
+            RemoteResponse::BadAuth => Err(RemoteError::BadAuth.into()),
+            RemoteResponse::Refused => Err(RemoteError::Refused.into()),
+            response => Ok(response),
+        }
+    }
+
+    let password = cli.password.unwrap_or_default();
+
+    match cli.command {
+        Command::Logout => {
+            let response = send_receive(
+                &mut stream,
+                RemoteRequest {
+                    password,
+                    command: RemoteCommand::Logout,
+                },
+            )?;
+
+            match response {
+                RemoteResponse::Ok => {
+                    eprintln!("OK");
+                    return Ok(());
+                }
+                _ => panic!("wrong response"),
+            }
+        }
+
+        Command::Sign {
+            psbt_in,
+            mode,
+            base64,
+            psbt_out,
+        } => {
+            let psbt = crate::load_psbt(&psbt_in)?;
+
+            let response = send_receive(
+                &mut stream,
+                RemoteRequest {
+                    password,
+                    command: RemoteCommand::SignPsbt {
+                        mode: mode.clone(),
+                        psbt,
+                    },
+                },
+            )?;
+
+            let tx = match response {
+                RemoteResponse::Psbt(tx) => tx,
+                _ => panic!("wrong response"),
+            };
+
+            let tx_string = match mode {
+                SignMode::Visualize => String::from_utf8(tx).unwrap(),
+                SignMode::VisualizeSigned => String::from_utf8(tx).unwrap(),
+                SignMode::Finalize if base64 => base64::encode(&tx),
+                SignMode::Finalize => hex::encode(&tx),
+            };
+
+            if let Some(psbt_out) = psbt_out {
+                let mut out = File::create(&psbt_out)?;
+                out.write_all(tx_string.as_bytes())?;
+            } else {
+                println!("{}", tx_string);
+            }
+        }
+
+        _ => return Err(RemoteError::NotRemoteCommand.into()),
+    };
+
+    Ok(())
+}
+
+/// Handles remote requests (server mode).
+pub(crate) fn listen(mut cc: Coldcard, password: &str) -> Result<(), Error> {
+    use libtor::{HiddenServiceVersion, Tor, TorAddress, TorFlag};
+
+    let tor_port = 8000;
+
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let internal_port = listener.local_addr()?.port();
+
+    let mut tor_dir = dirs::data_local_dir().expect("No data dir");
+    tor_dir.push("cc-tor");
+
+    let mut hs_dir = tor_dir.clone();
+    hs_dir.push("hs");
+
+    Tor::new()
+        .flag(TorFlag::DataDirectory(tor_dir.to_str().unwrap().to_owned()))
+        .flag(TorFlag::HiddenServiceDir(
+            hs_dir.to_str().unwrap().to_owned(),
+        ))
+        .flag(TorFlag::HiddenServiceVersion(HiddenServiceVersion::V3))
+        .flag(TorFlag::HiddenServicePort(
+            TorAddress::Port(tor_port),
+            Some(TorAddress::Port(internal_port)).into(),
+        ))
+        .start_background();
+
+    hs_dir.push("hostname");
+    let hostname = std::fs::read(hs_dir)?;
+    let hostname = String::from_utf8(hostname).expect("hostname not utf-8");
+
+    println!("Serving at {}:{}", hostname.trim(), tor_port);
+
+    fn handle(mut stream: TcpStream, cc: &mut Coldcard, password: &str) -> Result<bool, Error> {
+        let mut content_len = [0_u8; 4];
+
+        stream.read_exact(&mut content_len)?;
+        let content_len = u32::from_le_bytes(content_len) as usize;
+
+        let mut content = vec![0; content_len as usize];
+        stream.read_exact(&mut content)?;
+
+        let request: RemoteRequest = bincode::deserialize(&content)?;
+
+        if request.password != password {
+            let response_bytes = bincode::serialize(&RemoteResponse::BadAuth)?;
+            stream.write_all(&(response_bytes.len() as u32).to_le_bytes())?;
+            stream.write_all(&response_bytes)?;
+            eprintln!("bad auth with pwd: {}", request.password);
+            return Ok(false);
+        }
+
+        let (logout, response) = match request.command {
+            RemoteCommand::Logout => (true, RemoteResponse::Ok),
+
+            RemoteCommand::SignPsbt { mode, psbt } => {
+                cc.sign_psbt(&psbt, (&mode).into())?;
+
+                loop {
+                    crate::sleep();
+                    let tx = cc.get_signed_tx();
+                    match tx {
+                        Ok(Some(tx)) => break (false, RemoteResponse::Psbt(tx)),
+                        Ok(None) => continue,
+                        Err(coldcard::Error::UnexpectedResponse(_)) => {
+                            break (false, RemoteResponse::Refused)
+                        }
+                        Err(_) => break (false, RemoteResponse::ServerError),
+                    }
+                }
+            }
+        };
+
+        let response_bytes = bincode::serialize(&response)?;
+
+        stream.write_all(&(response_bytes.len() as u32).to_le_bytes())?;
+        stream.write_all(&response_bytes)?;
+
+        Ok(logout)
+    }
+
+    loop {
+        let (stream, _) = listener.accept()?;
+        let result = handle(stream, &mut cc, password);
+
+        match result {
+            Ok(true) => {
+                cc.logout()?;
+                return Ok(());
+            }
+            Ok(false) => {}
+            Err(error) => eprintln!("{:?}", error),
+        }
+
+        // throttle incoming requests to prevent grinding attacks
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+#[derive(Debug)]
+pub enum RemoteError {
+    NotRemoteCommand,
+    BadAuth,
+    Bincode(bincode::Error),
+    Refused,
+}
+
+impl From<bincode::Error> for Error {
+    fn from(error: bincode::Error) -> Self {
+        Error::Remote(RemoteError::Bincode(error))
+    }
+}


### PR DESCRIPTION
This PR adds the ability to start the CLI in the remote mode, creating a V3 .onion service for remote signing.