### PR TITLE
Small improvements to types

### DIFF
--- a/coldcard/src/lib.rs
+++ b/coldcard/src/lib.rs
@@ -707,6 +707,18 @@ pub enum Error {
     UserTimeout,
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
 impl From<Response> for Error {
     fn from(error: Response) -> Self {
         Self::UnexpectedResponse(error)

--- a/coldcard/src/protocol.rs
+++ b/coldcard/src/protocol.rs
@@ -81,6 +81,7 @@ impl Secret {
 
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AddressFormat {
     P2PKH = AFC_PUBKEY,
     P2SH = AFC_SCRIPT,


### PR DESCRIPTION
Just a couple of small things that make working with some of the types easier.

I've been using [thiserror](https://docs.rs/thiserror/latest/thiserror/) to create error types for my own crates; it's one of the few dependencies I add to almost all my libraries. For now I've just done the minimum to not introduce a dependency, but eventually it will make sense to improve the errors.