### PR TITLE
Feature improvements

### DIFF
--- a/51-coinkite.rules
+++ b/51-coinkite.rules
@@ -1,0 +1,16 @@
+# Linux udev support file.
+#
+# This is a example udev file for HIDAPI devices which changes the permissions
+# to 0666 (world readable/writable) for a specific device on Linux systems.
+#
+# - Copy this file into /etc/udev/rules.d and unplug and re-plug your Coldcard.
+# - Udev does not have to be restarted.
+#
+
+# probably not needed:
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="d13e", ATTRS{idProduct}=="cc10", GROUP="plugdev", MODE="0666"
+
+# required:
+# from <https://github.com/signal11/hidapi/blob/master/udev/99-hid.rules>
+KERNEL=="hidraw*", ATTRS{idVendor}=="d13e", ATTRS{idProduct}=="cc10", GROUP="plugdev", MODE="0666"
+

--- a/coldcard-cli/Cargo.toml
+++ b/coldcard-cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "coldcard-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-authors = ["Alfred Hodler <alfred_hodler AT protonmail DOT com>"]
+authors = ["Alfred Hodler <alfred_hodler@protonmail.com>"]
 license = "MIT"
 repository = "https://github.com/alfred-hodler/rust-coldcard/"
 description = "Coldcard Wallet CLI Tool"
@@ -10,9 +10,7 @@ keywords = ["coldcard", "bitcoin", "wallet"]
 categories = ["command-line-utilities", "cryptography::cryptocurrencies", "hardware-support"]
 
 [features]
-default = ["coldcard/default"]
-linux-static-hidraw = ["coldcard/linux-static-hidraw"]
-linux-static-libusb = ["coldcard/linux-static-libusb"]
+default = ["coldcard/default", "coldcard/log"]
 
 [[bin]]
 name = "coldcard"
@@ -20,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 bincode = "1.3.3"
-coldcard = { version = "0.4.0", path = "../coldcard" }
+coldcard = { version = "0.5.0", path = "../coldcard", default-features = false }
 dirs = "4.0.0"
 base64 = "0.13.0"
 clap = { version = "3.1.6", features = ["derive"] }
@@ -31,3 +29,4 @@ libtor = "47.7.0"
 rpassword = "6.0.1"
 serde = "1.0.137"
 socks = "0.3.4"
+env_logger = "0.9.1"

--- a/coldcard-cli/README.md
+++ b/coldcard-cli/README.md
@@ -66,6 +66,19 @@ SUBCOMMANDS:
     xpub           Show the xpub (default: master)
 ```
 
+## Linux Specific Instructions
+
+In order to be able to detect a Coldcard device on a Linux system, [51-coinkite.rules](../51-coinkite.rules) must be placed in `/etc/udev/rules.d/`.
+
+Two mutually exclusive HID backends are supported and can be turned on using the following features:
+
+* `coldcard/linux-static-hidraw` (default)
+* `coldcard/linux-static-libusb` (potential issues with [unclear error messages](https://github.com/libusb/hidapi/blob/f2e2b5b4d4caa9942ad2cd594da00956b51f0ca6/libusb/hid.c#L1637))
+
+## Logging
+
+To see log output, run the program with the `RUST_LOG=$level` environment variable. This uses the `env_logger` crate.
+
 ## Remote mode
 
 It is possible to start the CLI in the server mode, binding it to a locally connected Coldcard. This

--- a/coldcard-cli/src/main.rs
+++ b/coldcard-cli/src/main.rs
@@ -240,6 +240,8 @@ impl From<&SignMode> for coldcard::SignMode {
 }
 
 fn main() -> Result<(), Error> {
+    env_logger::init();
+
     let cli = Cli::parse();
 
     if cli.hidden_service.is_some() {

--- a/coldcard/Cargo.toml
+++ b/coldcard/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "coldcard"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-authors = ["Alfred Hodler <alfred_hodler AT protonmail DOT com>"]
+authors = ["Alfred Hodler <alfred_hodler@protonmail.com>"]
 license = "MIT"
 repository = "https://github.com/alfred-hodler/rust-coldcard/"
 description = "Coldcard Wallet Interface Library in Rust"
@@ -10,11 +10,12 @@ keywords = ["coldcard", "bitcoin", "wallet"]
 categories = ["command-line-utilities", "cryptography::cryptocurrencies", "hardware-support"]
 
 [features]
-default = ["hidapi/default"]
+default = ["linux-static-hidraw"]
 linux-static-hidraw = ["hidapi/linux-static-hidraw"]
 linux-static-libusb = ["hidapi/linux-static-libusb"]
 
 [dependencies]
 aes-ctr = "0.6.0"
 bitcoin = { version = "0.29.1", features = ["rand"] }
-hidapi = { version = "1.4.2", default-features = false }
+hidapi = { version = "1.3.3", default-features = false }
+log = { version = "0.4.17", optional = true }

--- a/coldcard/README.md
+++ b/coldcard/README.md
@@ -8,6 +8,7 @@
 use coldcard::protocol;
 
 // detect all connected Coldcards
+// (do not forget to set the required udev rule on Linux -- see below)
 let serials = coldcard::detect()?;
 
 // open a particular one
@@ -26,6 +27,19 @@ if let Some(xpub) = xpub {
 // secure logout
 coldcard.logout()?;
 ```
+
+## Linux Specific Instructions
+
+In order to be able to detect a Coldcard device on a Linux system, [51-coinkite.rules](../51-coinkite.rules) must be placed in `/etc/udev/rules.d/`.
+
+Two mutually exclusive HID backends are supported and can be turned on using the following features:
+
+* `linux-static-hidraw` (default)
+* `linux-static-libusb` (potential issues with [unclear error messages](https://github.com/libusb/hidapi/blob/f2e2b5b4d4caa9942ad2cd594da00956b51f0ca6/libusb/hid.c#L1637))
+
+## Logging
+
+The `log` feature enables logging using the `log` crate. Disabled by default. Use judiciously as logging can leak details into the environment.
 
 ## CLI
 


### PR DESCRIPTION
* basic logging is now available using the optional `log` feature

* `hidraw` is the default Linux HID backend

* add Linux udev instructions

* version `0.5.0`

@cloudhead `hidraw` is the default backend now since `libusb` has unclear error messages (see README for details). You should be able to use `hidraw` if you add the correct udev rules (as described in README), but if that doesn't work you can still opt for `linux-static-libusb`.