### PR TITLE
Add SignMode::Signed

### DIFF
--- a/coldcard/src/lib.rs
+++ b/coldcard/src/lib.rs
@@ -165,6 +165,7 @@ pub struct Backup {
 pub enum SignMode {
     Visualize = constants::STXN_VISUALIZE,
     VisualizeSigned = constants::STXN_VISUALIZE | constants::STXN_SIGNED,
+    Signed = constants::STXN_SIGNED,
     Finalize = constants::STXN_FINALIZE,
 }
 


### PR DESCRIPTION
With this mode, the device signs and returns the psbt filled with the signature and the pubkey.