### PR TITLE
coldcard: gate the `Api` interface behind a default "api" feature

### DIFF
--- a/coldcard/Cargo.toml
+++ b/coldcard/Cargo.toml
@@ -10,9 +10,10 @@ keywords = ["coldcard", "bitcoin", "wallet"]
 categories = ["command-line-utilities", "cryptography::cryptocurrencies", "hardware-support"]
 
 [features]
-default = ["linux-static-hidraw"]
+default = ["linux-static-hidraw", "api"]
 linux-static-hidraw = ["hidapi/linux-static-hidraw"]
 linux-static-libusb = ["hidapi/linux-static-libusb"]
+api = []
 
 [dependencies]
 aes-ctr = "0.6.0"

--- a/coldcard/src/lib.rs
+++ b/coldcard/src/lib.rs
@@ -43,6 +43,7 @@ pub mod firmware;
 pub mod protocol;
 pub mod util;
 
+#[cfg(feature = "api")]
 use std::sync::OnceLock;
 
 use protocol::{DerivationPath, DescriptorName, Request, Response, Username};
@@ -50,11 +51,14 @@ use protocol::{DerivationPath, DescriptorName, Request, Response, Username};
 pub const COINKITE_VID: u16 = 0xd13e;
 pub const CKCC_PID: u16 = 0xcc10;
 
+#[cfg(feature = "api")]
 static INIT: OnceLock<()> = OnceLock::new();
 
 /// API for interacting with Coldcard devices. Only one instance can exist per program lifetime.
+#[cfg(feature = "api")]
 pub struct Api(hidapi::HidApi);
 
+#[cfg(feature = "api")]
 impl Api {
     /// Creates a new API for interacting with Coldcard devices.
     ///
@@ -106,6 +110,7 @@ impl Api {
     }
 }
 
+#[cfg(feature = "api")]
 impl AsRef<hidapi::HidApi> for Api {
     fn as_ref(&self) -> &hidapi::HidApi {
         &self.0


### PR DESCRIPTION
`OnceCell` requires rustc 1.70, which is extremely new (6 months old). Gating its usage behind an on-by-default feature makes it possible for downstream users with a more conservative MSRV to use this crate without disrupting existing users.

For instance, we currently use 1.65 as our MSRV for the Liana GUI. This makes it possible to use this crate while respecting our MSRV.