### PR TITLE
Rework the API

### DIFF
--- a/coldcard-cli/Cargo.toml
+++ b/coldcard-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldcard-cli"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Alfred Hodler <alfred_hodler@protonmail.com>"]
 license = "MIT"
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 bincode = "1.3.3"
-coldcard = { version = "0.10.0", path = "../coldcard" }
+coldcard = { version = "0.11.0", path = "../coldcard" }
 dirs = "4.0.0"
 base64 = "0.13.0"
 clap = { version = "3.1.6", features = ["derive"] }

--- a/coldcard/Cargo.toml
+++ b/coldcard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldcard"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Alfred Hodler <alfred_hodler@protonmail.com>"]
 license = "MIT"


### PR DESCRIPTION
`HidApi` now appears to be safe to instantiate multiple times because it is lazily initialized only once for the lifetime of the program: https://docs.rs/hidapi/latest/hidapi/struct.HidApi.html

Users that wish to use their own `HidApi` instance can now pass it to `Api` using `from_borrowed(...)` or have one initialized internally using `new()`.