### PR TITLE
Various fixes

### DIFF
--- a/coldcard-cli/Cargo.toml
+++ b/coldcard-cli/Cargo.toml
@@ -19,14 +19,14 @@ path = "src/main.rs"
 [dependencies]
 coldcard = { version = "0.12.1", path = "../coldcard" }
 base64 = "0.21.7"
-clap = { version = "3.1.6", features = ["derive"] }
+clap = { version = "3.2.22", features = ["derive"] }
 hex = "0.4.3"
 hmac-sha256 = "1.1.7"
 indicatif = "0.17.7"
 json = "0.12.4"
 rpassword = "7.3.1"
-env_logger = "0.11.0"
+env_logger = "0.11.1"
 regex = "1.10.3"
-ureq = "2.9.1"
+ureq = "2.9.4"
 semver = "1.0.21"
 console = "0.15.8"

--- a/coldcard-cli/Cargo.toml
+++ b/coldcard-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldcard-cli"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["Alfred Hodler <alfred_hodler@protonmail.com>"]
 license = "MIT"
@@ -17,8 +17,8 @@ name = "coldcard"
 path = "src/main.rs"
 
 [dependencies]
-coldcard = { version = "0.12.0", path = "../coldcard" }
-base64 = "0.13.0"
+coldcard = { version = "0.12.1", path = "../coldcard" }
+base64 = "0.21.7"
 clap = { version = "3.1.6", features = ["derive"] }
 hex = "0.4.3"
 hmac-sha256 = "1.1.7"

--- a/coldcard-cli/README.md
+++ b/coldcard-cli/README.md
@@ -1,7 +1,6 @@
 # Coldcard CLI
 
-`coldcard-cli` is a CLI tool for interfacing with the [Coldcard](https://coldcard.com/) hardware wallet over USB.
-
+`coldcard-cli` is a firmware upgrade and general management tool for the [Coldcard](https://coldcard.com/) hardware wallet.
 
 Install it with:
 

--- a/coldcard-cli/src/fw_upgrade.rs
+++ b/coldcard-cli/src/fw_upgrade.rs
@@ -20,9 +20,10 @@ impl Release {
         let page = fetch_download_page()?;
 
         let mut found: Vec<_> = firmware_regex()
-            .find_iter(&page)
+            .captures_iter(&page)
             .map(|m| {
-                let version = version_regex().find(m.as_str()).unwrap();
+                let name = m.get(0).unwrap();
+                let version = m.get(1).unwrap();
                 let edge_marker = version.as_str().find('X');
                 let (version, is_edge) = match edge_marker {
                     Some(pos) => (Version::parse(&version.as_str()[1..pos]), true),
@@ -30,7 +31,7 @@ impl Release {
                 };
 
                 Release {
-                    name: m.as_str().to_owned(),
+                    name: name.as_str().to_owned(),
                     version: version.unwrap(),
                     is_edge,
                 }
@@ -94,10 +95,6 @@ fn fetch_download_page() -> Result<String, ureq::Error> {
 }
 
 fn firmware_regex() -> Regex {
-    Regex::new(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+X?(-mk.)?-coldcard.dfu")
+    Regex::new(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]+-(v[0-9]+\.[0-9]+\.[0-9]+X?)(-mk.)?-coldcard.dfu")
         .unwrap()
-}
-
-fn version_regex() -> Regex {
-    Regex::new(r"v[0-9]+\.[0-9]+\.[0-9]+X?").unwrap()
 }

--- a/coldcard/Cargo.toml
+++ b/coldcard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldcard"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["Alfred Hodler <alfred_hodler@protonmail.com>"]
 license = "MIT"
@@ -17,8 +17,8 @@ linux-static-libusb = ["hidapi/linux-static-libusb"]
 [dependencies]
 aes-ctr = "0.6.0"
 base58 = "0.2.0"
-bitcoin_hashes = "0.12.0"
+bitcoin_hashes = "0.13.0"
 hidapi = { version = "2.4.1", default-features = false }
-k256 = { version = "0.13.1", features = ["arithmetic"] }
-log = { version = "0.4.17", optional = true }
+k256 = { version = "0.13.3", features = ["arithmetic"] }
+log = { version = "0.4.20", optional = true }
 rand = "0.8.5"

--- a/coldcard/Cargo.toml
+++ b/coldcard/Cargo.toml
@@ -15,10 +15,11 @@ linux-static-hidraw = ["hidapi/linux-static-hidraw"]
 linux-static-libusb = ["hidapi/linux-static-libusb"]
 
 [dependencies]
-aes-ctr = "0.6.0"
+aes = "0.8.3"
 base58 = "0.2.0"
 bitcoin_hashes = "0.13.0"
-hidapi = { version = "2.4.1", default-features = false }
+ctr = "0.9.2"
+hidapi = { version = "2.5.1", default-features = false }
 k256 = { version = "0.13.3", features = ["arithmetic"] }
 log = { version = "0.4.20", optional = true }
 rand = "0.8.5"

--- a/coldcard/src/firmware.rs
+++ b/coldcard/src/firmware.rs
@@ -53,8 +53,12 @@ impl Firmware {
             if (0..elements).next().is_some() {
                 let mut eprefix = [0_u8; 8];
                 stream.read_exact(&mut eprefix)?;
+                let address = decode_u32(eprefix.get(0..4))?;
                 let size = decode_u32(eprefix.get(4..8))?;
 
+                if address < 0x8008000 {
+                    return Err(Error::BadAddress);
+                }
                 if size % 256 != 0 {
                     return Err(Error::UnalignedSize);
                 }


### PR DESCRIPTION
* Handle the `fram` error message in a way that mitigates a firmware bug: `FramingError` being raised by the firmware does not set the `is_last` flag correctly, causing our end of the wire to hang. This addresses that problem.

* CLI: correctly resync on open.

* upgrade dependencies (`aes-ctr` was deprecated)

* update the firmware parsing regex