### PR TITLE
Add type to fix nightly build

### DIFF
--- a/coldcard/src/protocol/derivation_path.rs
+++ b/coldcard/src/protocol/derivation_path.rs
@@ -13,7 +13,7 @@ impl DerivationPath {
             _ => return Err(Error::InvalidFormat),
         }
 
-        let children = segments.map(|c| c.parse()).collect::<Result<Box<_>, _>>()?;
+        let children: Box<[Child]> = segments.map(|c| c.parse()).collect::<Result<_, _>>()?;
 
         if children.len() > 12 {
             return Err(Error::TooDeep);


### PR DESCRIPTION
This is related to https://github.com/rust-lang/rust/issues/125319.

It seems that the type can no longer be inferred and so I've added it explicitly.