### PR TITLE
add new features introduced by firmware 6.4.0

### DIFF
--- a/coldcard-cli/src/main.rs
+++ b/coldcard-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
-use coldcard::protocol::{self, derivation_path, Response};
+use coldcard::protocol::{self, derivation_path, DescriptorName, Response};
 use coldcard::{firmware, Backup, Options, SignedMessage};
 use coldcard::{util, XpubInfo};
 
@@ -52,6 +52,20 @@ enum Command {
         /// The path to the file where the backup should be saved,
         /// including the filename
         path: PathBuf,
+    },
+
+    /// Restore a backup from file
+    Restore {
+        path: PathBuf,
+        /// Backup is encrypted with a custom password
+        #[clap(short, long, action = clap::ArgAction::SetTrue)]
+        password: bool,
+        /// Backup is clear-text (dev)
+        #[clap(short, long, action = clap::ArgAction::SetTrue)]
+        plaintext: bool,
+        /// force load as tmp, effective only on seed-less CC
+        #[clap(short, long, action = clap::ArgAction::SetTrue)]
+        tmp: bool,
     },
 
     /// Show the bag number the Coldcard arrived in
@@ -138,6 +152,9 @@ enum Command {
         base64: bool,
         /// The optional path where to write out the signed tx (default: stdout)
         psbt_out: Option<PathBuf>,
+        /// Optional miniscript wallet name
+        #[clap(long)]
+        miniscript: Option<String>,
     },
 
     /// Test USB connection
@@ -181,6 +198,13 @@ enum Command {
         #[clap(long)]
         xfp: bool,
     },
+
+    /// List miniscript descriptors
+    MiniscriptList,
+    /// Delete a registered miniscript policy
+    MiniscriptDelete { name: String },
+    /// Get a registered miniscript policy by its name
+    MiniscriptPolicy { name: String },
 }
 
 #[derive(clap::ArgEnum, Clone)]
@@ -548,11 +572,23 @@ fn handle(cli: Cli) -> Result<(), Error> {
             psbt_out,
             mode,
             base64,
+            miniscript,
         } => {
             let psbt = load_psbt(&psbt_in)?;
             let sign_mode = (&mode).into();
+            let miniscript = if let Some(name) = miniscript {
+                match DescriptorName::new(name) {
+                    Ok(m) => Some(m),
+                    Err(e) => {
+                        eprintln!("ERROR: Invalid miniscript descriptor name: {e:?}.");
+                        return Ok(());
+                    }
+                }
+            } else {
+                None
+            };
 
-            cc.sign_psbt(&psbt, sign_mode)?;
+            cc.sign_psbt_miniscript(&psbt, sign_mode, miniscript)?;
 
             let tx = loop {
                 sleep();
@@ -781,6 +817,68 @@ fn handle(cli: Cli) -> Result<(), Error> {
                 xpub = xpub_version::convert_bytes(&xpub, version.into())?;
             }
             println!("{}", xpub);
+        }
+        Command::MiniscriptList => {
+            let resp = cc.miniscript_list()?;
+            for m in resp {
+                println!("{m}");
+            }
+        }
+        Command::MiniscriptDelete { name } => {
+            let descriptor_name = match DescriptorName::new(name.clone()) {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("ERROR: Invalid miniscript descriptor name: {e:?}.");
+                    return Ok(());
+                }
+            };
+            if let Err(e) = cc.delete_miniscript(descriptor_name) {
+                eprintln!("ERROR: Fail to delete descriptor {name}: {e:?}")
+            }
+        }
+        Command::MiniscriptPolicy { name } => {
+            let descriptor_name = match DescriptorName::new(name.clone()) {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("ERROR: Invalid miniscript descriptor name: {e:?}.");
+                    return Ok(());
+                }
+            };
+            match cc.bip388_policy_get(descriptor_name) {
+                Ok(Some(p)) => println!("{p}"),
+                Err(e) => {
+                    eprintln!("ERROR: Fail to get miniscript policy for name {name}: {e:?}")
+                }
+                _ => {
+                    eprintln!("ERROR: No descriptor found with name {name}");
+                }
+            }
+        }
+        Command::Restore {
+            password,
+            path,
+            plaintext,
+            tmp,
+        } => {
+            if !path.exists() {
+                eprintln!("ERROR: Path {} does not exists", path.to_str().unwrap());
+                return Ok(());
+            }
+            if !path.is_file() {
+                eprintln!("ERROR: Path {} is not a file", path.to_str().unwrap());
+                return Ok(());
+            }
+            let mut file = match File::open(path.clone()) {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("ERROR: Fail to open file {}: {e}", path.to_str().unwrap());
+                    return Ok(());
+                }
+            };
+            let mut data = vec![];
+            let _ = file.read_to_end(&mut data);
+
+            cc.restore_backup(&data, password, plaintext, tmp)?
         }
     }
 

--- a/coldcard-cli/src/main.rs
+++ b/coldcard-cli/src/main.rs
@@ -240,6 +240,8 @@ enum SignMode {
     VisualizeSigned,
     /// Finalize the transaction
     Finalize,
+    /// Sign the transaction
+    Sign,
 }
 
 impl From<AuthMode> for protocol::AuthMode {
@@ -258,6 +260,7 @@ impl From<&SignMode> for coldcard::SignMode {
             SignMode::Visualize => coldcard::SignMode::Visualize,
             SignMode::VisualizeSigned => coldcard::SignMode::VisualizeSigned,
             SignMode::Finalize => coldcard::SignMode::Finalize,
+            SignMode::Sign => coldcard::SignMode::Signed,
         }
     }
 }
@@ -604,6 +607,7 @@ fn handle(cli: Cli) -> Result<(), Error> {
                 SignMode::VisualizeSigned => String::from_utf8(tx).unwrap(),
                 SignMode::Finalize if base64 => b64_encode(&tx),
                 SignMode::Finalize => hex::encode(&tx),
+                SignMode::Sign => hex::encode(tx),
             };
 
             if let Some(psbt_out) = psbt_out {

--- a/coldcard-cli/src/main.rs
+++ b/coldcard-cli/src/main.rs
@@ -877,6 +877,7 @@ fn warn(text: &str) {
     eprintln!("{} {}", prefix.apply_to("WARNING:"), text);
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum Error {
     Coldcard(coldcard::Error),

--- a/coldcard/src/lib.rs
+++ b/coldcard/src/lib.rs
@@ -630,12 +630,25 @@ impl Coldcard {
     /// Initiates PSBT signing and causes the Coldcard to prompt the user to confirm.
     /// This does not immediately return a signed tx, use `get_signed_tx` for that.
     pub fn sign_psbt(&mut self, psbt: &[u8], sign_mode: SignMode) -> Result<(), Error> {
+        self.sign_psbt_miniscript(psbt, sign_mode, None)
+    }
+
+    /// Initiates PSBT signing for a miniscript wallet and causes the Coldcard to
+    /// prompt the user to confirm. This does not immediately return a signed tx,
+    /// use `get_signed_tx` for that.
+    pub fn sign_psbt_miniscript(
+        &mut self,
+        psbt: &[u8],
+        sign_mode: SignMode,
+        descriptor_name: Option<DescriptorName>,
+    ) -> Result<(), Error> {
         let file_sha = self.upload(psbt, |_, _| {})?;
 
         self.send(Request::SignTransaction {
             length: psbt.len() as u32,
             file_sha,
             flags: Some(sign_mode as u32),
+            descriptor_name,
         })?
         .into_ok()
         .map_err(Error::from)
@@ -716,6 +729,28 @@ impl Coldcard {
         self.send(Request::GetXPub(path))?
             .into_ascii()
             .map_err(Error::from)
+    }
+
+    /// Gets the BIP-0388 wallet policy of a given wallet
+    pub fn bip388_policy_get(
+        &mut self,
+        descriptor_name: DescriptorName,
+    ) -> Result<Option<String>, Error> {
+        let response = match self.send(Request::MiniscriptPolicy { descriptor_name }) {
+            Ok(response) => response,
+            Err(Error::Decoding(protocol::DecodeError::Protocol(e))) => {
+                // FIXME:
+                if e == "Miniscript wallet not found" {
+                    return Ok(None);
+                } else {
+                    return Err(Error::Decoding(protocol::DecodeError::Protocol(e)));
+                }
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        };
+        response.into_ascii().map(Some).map_err(Error::from)
     }
 }
 

--- a/coldcard/src/lib.rs
+++ b/coldcard/src/lib.rs
@@ -572,6 +572,32 @@ impl Coldcard {
         .into_ok()
         .map_err(Error::from)
     }
+    /// Restore a backup
+    pub fn restore_backup(
+        &mut self,
+        data: &[u8],
+        // Backup is .7z encrypted with custom password
+        custom_pwd: bool,
+        // Backup is clear-text (dev)
+        plaintext: bool,
+        // force load as tmp, effective only on seed-less CC
+        tmp: bool,
+    ) -> Result<(), Error> {
+        if custom_pwd && plaintext {
+            return Err(Error::RestoreBackupFlags);
+        }
+        let file_sha = self.upload(data, |_, _| {})?;
+
+        self.send(Request::RestoreBackup {
+            length: data.len() as u32,
+            file_sha,
+            custom_pwd,
+            plaintext,
+            tmp,
+        })?
+        .into_ok()
+        .map_err(Error::from)
+    }
 
     /// Get registered descriptor by name.
     pub fn miniscript_get(
@@ -939,6 +965,7 @@ pub enum Error {
     ChecksumMismatch,
     TransmissionFailed,
     TestFailureWithLength(usize),
+    RestoreBackupFlags,
 }
 
 impl std::fmt::Display for Error {

--- a/coldcard/src/lib.rs
+++ b/coldcard/src/lib.rs
@@ -43,7 +43,7 @@ pub mod protocol;
 pub mod util;
 
 use protocol::{DerivationPath, DescriptorName, Request, Response, Username};
-use util::MaybeOwned;
+use util::{parse_string_vec, MaybeOwned};
 
 type Aes256Ctr = ctr::Ctr64BE<aes::Aes256>;
 
@@ -628,6 +628,13 @@ impl Coldcard {
             }
         };
         response.into_ascii().map(Some).map_err(Error::from)
+    }
+
+    /// List miniscript descriptors registered on the device
+    pub fn miniscript_list(&mut self) -> Result<Vec<String>, Error> {
+        let resp = self.send(Request::MiniscriptList)?.into_ascii()?;
+        let miniscripts = parse_string_vec(&resp);
+        Ok(miniscripts)
     }
 
     /// Reboots the Coldcard.

--- a/coldcard/src/lib.rs
+++ b/coldcard/src/lib.rs
@@ -599,6 +599,16 @@ impl Coldcard {
         .map_err(Error::from)
     }
 
+    /// Delete a registered miniscript descriptor
+    pub fn delete_miniscript(&mut self, descriptor_name: DescriptorName) -> Result<(), Error> {
+        if descriptor_name.0.len() > 40 || !descriptor_name.0.is_ascii() {
+            return Err(Error::DescriptorName);
+        }
+        self.send(Request::MiniscriptDelete { descriptor_name })?
+            .into_ok()
+            .map_err(Error::from)
+    }
+
     /// Get registered descriptor by name.
     pub fn miniscript_get(
         &mut self,
@@ -966,6 +976,7 @@ pub enum Error {
     TransmissionFailed,
     TestFailureWithLength(usize),
     RestoreBackupFlags,
+    DescriptorName,
 }
 
 impl std::fmt::Display for Error {

--- a/coldcard/src/lib.rs
+++ b/coldcard/src/lib.rs
@@ -250,6 +250,7 @@ impl Coldcard {
         let cc_pk = k256::PublicKey::from_sec1_bytes(&prefixed_cc_pk)?;
         let session_key = session_key(our_sk, cc_pk)?;
 
+        #[allow(deprecated)]
         let (encrypt, decrypt) = {
             use aes::cipher::{generic_array::GenericArray, KeyIvInit};
 

--- a/coldcard/src/protocol.rs
+++ b/coldcard/src/protocol.rs
@@ -125,6 +125,7 @@ pub enum Request {
         length: u32,
         file_sha: [u8; 32],
         flags: Option<u32>,
+        descriptor_name: Option<DescriptorName>,
     },
     SignMessage {
         raw_msg: Message,
@@ -134,6 +135,9 @@ pub enum Request {
     GetSignedMessage,
     GetBackupFile,
     GetSignedTransaction,
+    MiniscriptPolicy {
+        descriptor_name: DescriptorName,
+    },
     MiniscriptAddress {
         descriptor_name: DescriptorName,
         change: bool,
@@ -253,12 +257,17 @@ impl Request {
                 length,
                 file_sha,
                 flags,
+                descriptor_name: miniscript_name,
             } => {
                 let mut buf = cmd("stxn");
                 let flags = flags.unwrap_or_default();
                 buf.extend(length.to_le_bytes());
                 buf.extend(flags.to_le_bytes());
                 buf.extend(file_sha);
+                if let Some(name) = miniscript_name {
+                    buf.extend((name.0.len() as u8).to_le_bytes());
+                    buf.extend(name.0);
+                }
                 buf
             }
 
@@ -418,6 +427,13 @@ impl Request {
             }
 
             Request::GetStorageLocker => cmd("gslr"),
+            Request::MiniscriptPolicy {
+                descriptor_name: name,
+            } => {
+                let mut buf = cmd("mspl");
+                buf.extend(name.0);
+                buf
+            }
         }
     }
 }
@@ -716,6 +732,21 @@ mod tests {
                 length: 345,
                 file_sha: BYTES_32.to_owned(),
                 flags: Some(STXN_FINALIZE | STXN_SIGNED | STXN_VISUALIZE),
+                descriptor_name: None,
+            },
+        );
+
+        encode_eq(
+            &[
+                115, 116, 120, 110, 89, 1, 0, 0, 7, 0, 0, 0, 82, 246, 129, 254, 167, 146, 135, 174,
+                60, 60, 152, 151, 192, 167, 53, 120, 248, 31, 108, 213, 131, 160, 94, 44, 58, 189,
+                111, 107, 237, 24, 89, 172, 4, 116, 101, 115, 116,
+            ],
+            Request::SignTransaction {
+                length: 345,
+                file_sha: BYTES_32.to_owned(),
+                flags: Some(STXN_FINALIZE | STXN_SIGNED | STXN_VISUALIZE),
+                descriptor_name: Some(DescriptorName::new("test").unwrap()),
             },
         );
 

--- a/coldcard/src/protocol.rs
+++ b/coldcard/src/protocol.rs
@@ -157,6 +157,7 @@ pub enum Request {
         length: u32,
         file_sha: [u8; 32],
     },
+    MiniscriptList,
     MiniscriptDelete {
         descriptor_name: DescriptorName,
     },
@@ -476,6 +477,7 @@ impl Request {
                 buf.extend(descriptor_name.0);
                 buf
             }
+            Request::MiniscriptList => cmd("msls"),
         }
     }
 }

--- a/coldcard/src/protocol.rs
+++ b/coldcard/src/protocol.rs
@@ -29,7 +29,7 @@ macro_rules! impl_new_with_range {
     };
 }
 
-pub struct DescriptorName(Vec<u8>);
+pub struct DescriptorName(pub(crate) Vec<u8>);
 pub struct Upload(Vec<u8>);
 pub struct Message(Vec<u8>);
 pub struct Username(Vec<u8>);
@@ -156,6 +156,9 @@ pub enum Request {
     MiniscriptEnroll {
         length: u32,
         file_sha: [u8; 32],
+    },
+    MiniscriptDelete {
+        descriptor_name: DescriptorName,
     },
     MiniscriptGetDescriptor {
         descriptor_name: DescriptorName,
@@ -466,6 +469,11 @@ impl Request {
                 buf.extend(file_sha);
                 buf.push(flags);
 
+                buf
+            }
+            Request::MiniscriptDelete { descriptor_name } => {
+                let mut buf = cmd("msdl");
+                buf.extend(descriptor_name.0);
                 buf
             }
         }

--- a/coldcard/src/protocol.rs
+++ b/coldcard/src/protocol.rs
@@ -106,6 +106,16 @@ pub enum Request {
     GetPassphraseDone,
     CheckMitm,
     StartBackup,
+    RestoreBackup {
+        length: u32,
+        file_sha: [u8; 32],
+        //custom_pwd: (bool) .7z encrypted with custom password
+        custom_pwd: bool,
+        //plaintext:  (bool)  clear-text (dev)
+        plaintext: bool,
+        //tmp         (bool)  force load as tmp, effective only on seed-less CC
+        tmp: bool,
+    },
     EncryptStart {
         device_pubkey: [u8; 64],
         version: Option<u32>,
@@ -432,6 +442,30 @@ impl Request {
             } => {
                 let mut buf = cmd("mspl");
                 buf.extend(name.0);
+                buf
+            }
+            Request::RestoreBackup {
+                length,
+                file_sha,
+                custom_pwd,
+                plaintext,
+                tmp,
+            } => {
+                let mut flags = 0u8;
+                if custom_pwd {
+                    flags |= 1;
+                }
+                if plaintext {
+                    flags |= 2;
+                }
+                if tmp {
+                    flags |= 4;
+                }
+                let mut buf = cmd("rest");
+                buf.extend(length.to_le_bytes());
+                buf.extend(file_sha);
+                buf.push(flags);
+
                 buf
             }
         }

--- a/coldcard/src/protocol.rs
+++ b/coldcard/src/protocol.rs
@@ -829,9 +829,6 @@ mod tests {
 
         encode_eq(b"blkc", Request::Blockchain);
 
-        #[cfg(feature = "simulator")]
-        encode_eq(b"XKEY\x01", Request::SimKeypress(0x01));
-
         encode_eq(b"bagi", Request::BagNumber(None));
         encode_eq(
             b"bagi123abc",

--- a/coldcard/src/protocol/derivation_path.rs
+++ b/coldcard/src/protocol/derivation_path.rs
@@ -69,7 +69,7 @@ impl std::str::FromStr for Child {
     type Err = Error;
 
     fn from_str(c: &str) -> Result<Self, Self::Err> {
-        let is_hardened = c.chars().last().map_or(false, |l| l == '\'' || l == 'h');
+        let is_hardened = c.chars().last().is_some_and(|l| l == '\'' || l == 'h');
         let i: u32 = (if is_hardened { &c[0..c.len() - 1] } else { c })
             .parse()
             .map_err(|_| Error::InvalidChild)?;

--- a/coldcard/src/util.rs
+++ b/coldcard/src/util.rs
@@ -48,7 +48,7 @@ pub enum MaybeOwned<'a, T> {
     Borrowed(&'a mut T),
 }
 
-impl<'a, T> AsRef<T> for MaybeOwned<'a, T> {
+impl<T> AsRef<T> for MaybeOwned<'_, T> {
     fn as_ref(&self) -> &T {
         match self {
             MaybeOwned::Owned(owned) => owned,
@@ -57,7 +57,7 @@ impl<'a, T> AsRef<T> for MaybeOwned<'a, T> {
     }
 }
 
-impl<'a, T> AsMut<T> for MaybeOwned<'a, T> {
+impl<T> AsMut<T> for MaybeOwned<'_, T> {
     fn as_mut(&mut self) -> &mut T {
         match self {
             MaybeOwned::Owned(owned) => owned,

--- a/coldcard/src/util.rs
+++ b/coldcard/src/util.rs
@@ -65,3 +65,34 @@ impl<T> AsMut<T> for MaybeOwned<'_, T> {
         }
     }
 }
+
+pub fn parse_string_vec(response: &str) -> Vec<String> {
+    // expected input kind: ["Liana-rkkrtqy6", "Liana-947xsd0w"]
+    let resp = response.replace("\"", "");
+    let end = resp.len() - 1;
+    let resp = resp[1..end].to_string();
+    resp.split(",").map(|s| s.trim().to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_string_vec() {
+        // 2 entries
+        let response = "[\"Liana-rkkrtqy6\", \"Liana-947xsd0w\"]";
+        let parsed = parse_string_vec(response);
+        assert_eq!(parsed, vec!["Liana-rkkrtqy6", "Liana-947xsd0w"]);
+
+        // 1 entry
+        let response = "[\"solo\"]";
+        let parsed = parse_string_vec(response);
+        assert_eq!(parsed, vec!["solo"]);
+
+        // empty entry
+        let response = "[]";
+        let parsed = parse_string_vec(response);
+        assert_eq!(parsed, vec![""]);
+    }
+}


### PR DESCRIPTION
This PR:
- pin `base64ct` to `<1.8.0` as from `1.8.0` require rust edition 2024
- clippyfy & cleanup
- implements several request that were previously not:
  - restore_backup()
  - miniscript_list()
  - miniscript_delete()
- implements new requests to be release in upcoming EDGE 6.4.0 firmware:
  - miniscript_policy()
  - add an optionnal descriptor_name arg to sign()
- add commands to the cli for added requests
- add the possibility to sign with tag [STXN_SIGNED](https://github.com/scgbckbone/ckcc-protocol/blob/a833ceb6c26e307f6b034dbfdba9356c966c632f/ckcc/constants.py#L71) in the cli